### PR TITLE
improves the dotnet deploying guide

### DIFF
--- a/deploying-diego.html.md.erb
+++ b/deploying-diego.html.md.erb
@@ -9,14 +9,14 @@ This topic contains instructions for setting up a Windows instance in a Diego de
 * A working Diego deployment
 * A Windows Server 2012R2 VM instance that is routable to your Diego deployment.
   Recommended:
-  * **r3.xlarge**, see [https://github.com/cloudfoundry-incubator/diego-release/commit/c9331bc1b1000bd135cb99a025a3680d1a12ac87](https://github.com/cloudfoundry-incubator/diego-release/commit/c9331bc1b1000bd135cb99a025a3680d1a12ac87)
-  * Windows ISO SHA1: B6F063436056510357CB19CB77DB781ED9C11DF3
+  * **r3.xlarge**, see [Diego's recommended instance types](https://github.com/cloudfoundry-incubator/diego-release/tree/3b229e0b971402387bd7c1831e96b2a177cbfcae#recommended-instance-types)
+  * If you are creating a new windows image (as opposed to using a predefined image by your IAAS), we recommend using this [ISO image](https://msdn.microsoft.com/subscriptions/json/GetDownloadRequest?brand=MSDN&locale=en-us&fileId=62611&activexDisabled=true&akamaiDL=false) as a starting point. You will need an MSDN account to be able to download the iso file.
 
 ## <a id='install-windows-server'></a> Step 1: Set Up the Windows Cell ##
 
-1. Download the `setup.ps1` file from [Pivotal Network](https://network.pivotal.io/products/pivotal-diego-pcf).
+1. Download the `setup.ps1` file from [Pivotal Network](https://network.pivotal.io/products/pivotal-diego-pcf). **NOTE**: make sure you are logged in to Pivotal Network before clicking on the link.
 
-1. From your file explorer, right-click the downloaded `setup.ps1` file and
+1. On the windows cell, open file explorer, right-click the downloaded `setup.ps1` file and
 click **Run with powershell**.
 The script configures the required Windows features, DNS settings, and your
 firewall for your Windows cell.
@@ -26,15 +26,15 @@ firewall for your Windows cell.
 Install the MSI by running a command that sets your environment variables.
 The command depends on the version of the MSI you are using.
 
-<p class='note'><strong>Note</strong>: The following instructions assume that the MSI was downloaded to <code>C:\temp\Diego_Windows_v0_148.msi</code>.</p>
+<p class='note'><strong>Note</strong>: The following instructions assume that the MSI was downloaded to <code>C:\temp\Diego_Windows_v0_148.msi</code>. Don not worry about figuring out the values to use below, this is covered in other sections below.</p>
 
 <pre class='terminal'>
 $ msiexec /norestart /i c:\temp\Diego_Windows_v0_148.msi ^
   ADMIN_USERNAME=[Username with admin privileges] ^
   ADMIN_PASSWORD=[Previous user password] ^
   CONSUL_IPS=[Comma-separated IP addresses of consul agents from BOSH deploy of CF] ^
-  ETCD_CLUSTER=[URI of your Diego etcd cluster from BOSH deploy] ^
-  CF_ETCD_CLUSTER=[URI of your Elastic Runtime CF etcd cluster from bosh deploy of cf] ^
+  ETCD_CLUSTER=[URL of your Diego etcd cluster from BOSH deploy] ^
+  CF_ETCD_CLUSTER=[URL of your Elastic Runtime CF etcd cluster from bosh deploy of cf] ^
   STACK=[CF Stack (e.g., windows2012R2)] ^
   REDUNDANCY_ZONE=[Diego zone that this cell is part of] ^
   LOGGREGATOR_SHARED_SECRET=[loggregator secret from your BOSH deploy of CF] ^
@@ -75,9 +75,9 @@ Locate your **consul** job and copy the comma-separated list of IP addresses.
 
 ### <a id='opsman-etcd-cluster'></a>ETCD_CLUSTER ###
 
-URI for the Diego etcd cluster from your Cloud Foundry BOSH deployment.
+URL of the etcd cluster from your Diego BOSH deployment.
 
-Navigate to your PCF Ops Manager dashboard, click the **Diego** tile, and select
+Navigate to your PCF Ops Manager dashboard, click the **Diego for PCF** tile, and select
 **Status**.
 Locate your **etcd** job and copy the IP addresses.
 Run the following command to ensure you can connect to the etcd server from Ops Manager:
@@ -88,7 +88,7 @@ $ curl http://ETCD-SERVER-IP:4001/v2/keys/message -XPUT -d value="Hello diego"
 
 ### <a id='opsman-cf-etcd-cluster'></a>CF\_ETCD\_CLUSTER ###
 
-URI for the Elastic Runtime cf etcd cluster from your Cloud Foundry BOSH
+URL for the Elastic Runtime cf etcd cluster from your Cloud Foundry BOSH
 deployment.
 
 Navigate to your PCF Ops Manager dashboard, click the **Pivotal Elastic Runtime** tile, and select **Status**.
@@ -138,14 +138,22 @@ The **Shared Secret Credentials** information is formatted as `XXXXXXXXXX / YOUR
 
 ## <a id='confirm-deployment'></a> Step 3: Confirm Successful Deployment ##
 
-1. After successful deployment, the following jobs are running:
-  * Consul
-  * Containerizer
-  * Executor
-  * GardenWindows
-  * Rep
+1. If everything has worked correctly, you should now see the
+   following five services running in the Task Manager (it's easier to
+   sort the services using the `Description` column and look for
+   descriptions starting with `CF `):
 
-1. Browse to `http://receptor.YOUR-DOMAIN/v1/cells` to view the Windows cells.
+   | Name          | Description      | Status  |
+   |---------------|------------------|---------|
+   | Consul        | CF Consul        | Running |
+   | Containerizer | CF Containerizer | Running |
+   | Executor      | CF Executor      | Running |
+   | GardenWindows | CF GardenWindows | Running |
+   | Metron        | CF Metron        | Running |
+   | Rep           | CF Rep           | Running |
+
+1. Browse to `http://receptor.YOUR-DOMAIN/v1/cells` and search for `windows2012R2` to view the Windows cells.
+
 For example:
 
 ```json


### PR DESCRIPTION
- make it clear that the windows iso is only required if the user isn't
  using an IAAS
- make it clear that the pivnet link requires authentication
- adds a note that the installer variables are explained later in the
  document
- URI -> URL
- Diego -> Diego for PCF (for consistency)
- Add the services table and a hint to sort by service description to
  make it easier to locate the CF services

Signed-off-by: John_Shahid <jshahid@pivotal.io>