### PR TITLE
Hard code redundancy zone

### DIFF
--- a/deploying-diego.html.md.erb
+++ b/deploying-diego.html.md.erb
@@ -65,34 +65,7 @@ deployment.
 
 ### <a id='zone'></a>ZONE / REDUNDANCY_ZONE ###
 
-The BOSH redundancy zone that contains this cell as a member.
-
-  * Navigate to your PCF Ops Manager Dashboard, click the **Diego for PCF** 
-  tile, and select **Credentials**.
-  Locate the username and password for **Receptor Credentials** and navigate to 
-  `http://receptor.YOUR-DOMAIN/v1/cells`.
-  <br><br>
-  You should see `zone` listed inside each existing cell, as the example below
-  shows:
-  <pre>
-  [
-     {
-        "cell\_id":"cell-partition-880c1d1dca06bbf67e1-0",
-        "zone":"0880c1d1dca06bbf67e1",
-        "capacity":{
-           "memory\_mb":30679,
-           "disk\_mb":15993,
-           "containers":256
-        }
-     }
-  ]
-  </pre>
-  If you are using AWS, navigate to **EC2 Dashboard>Instances** on your AWS 
-  Console and select the instance name to find the zone. 
-  AWS displays the zone with the instance name, in the format `INSTANCE-ZONE`.
-  <br><br>
-  For example, the EC2 instance `nats-partition-012345abcde` exists within the 
-  zone `012345abcde`.
+Use the value `windows` for this field (see examples below)
 
 ### <a id='log-shared-secret'></a>LOGGREGATOR\_SHARED\_SECRET ###
 
@@ -117,7 +90,7 @@ $ msiexec /norestart /i ABSOLUTE_PATH_TO_MSI\Diego_Windows_v0_148.msi ^
   CONSUL_IPS=[Comma-separated IP addresses of consul agents from BOSH deploy of CF] ^
   CF_ETCD_CLUSTER=[URL of your Elastic Runtime CF etcd cluster from BOSH deploy of CF] ^
   STACK=[CF Stack (e.g., windows2012R2)] ^
-  REDUNDANCY_ZONE=[Diego zone that contains this cell as a member] ^
+  REDUNDANCY_ZONE=windows ^
   LOGGREGATOR_SHARED_SECRET=[Loggregator secret from your BOSH deploy of CF] ^
   EXTERNAL_IP=[External IP of Windows VM] ^
   MACHINE_NAME=[Name of this machine. Note: Must be unique across your cluster]
@@ -134,7 +107,7 @@ $ msiexec /norestart /i c:\temp\Diego_Windows_v0_148.msi ^
   CONSUL_IPS=10.10.5.11,10.10.6.11,10.10.7.11 ^
   CF_ETCD_CLUSTER=http://10.244.0.42:4001 ^
   STACK=windows2012R2 ^
-  REDUNDANCY_ZONE=0c35dfe1cf34ec47e2a2 ^
+  REDUNDANCY_ZONE=windows ^
   LOGGREGATOR_SHARED_SECRET=loggregator-secret ^
   EXTERNAL_IP=10.10.5.35 ^
   MACHINE_NAME=WIN-RD649GEUDP1

--- a/deploying-diego.html.md.erb
+++ b/deploying-diego.html.md.erb
@@ -14,9 +14,16 @@ information on Diego Beta.
 * A working Diego deployment
 * A Windows Server 2012R2 VM instance that is routable to your Diego deployment
     * See [recommended instance types](https://github.com/cloudfoundry-incubator/diego-release/tree/3b229e0b971402387bd7c1831e96b2a177cbfcae#recommended-instance-types) in the GitHub Diego release repo for details.
+    * A new subnet for the windows cell (See [windows subnet](#windows-subnet))
     * If you are creating a new Windows image, and not using one predefined and 
 supplied by your IaaS, we recommend using this [ISO image](https://msdn.microsoft.com/subscriptions/json/GetDownloadRequest?brand=MSDN&locale=en-us&fileId=62611&activexDisabled=true&akamaiDL=false) as a starting 
 point. You must have an MSDN account to download this ISO image.
+
+## <a id='windows-subnet'></a> Windows subnet ##
+
+In order to avoid conflicting with bosh, the windows cell shouldn't be
+using an ip range that is being used by bosh. Otherwise, a bosh deploy
+would fail if the windows cell happened to be using an ip that bosh needs.
 
 ## <a id='cell'></a>Step 1: Configure the Windows Cell ##
 


### PR DESCRIPTION
This pr introduces two changes:

1. Note that `REDUNDANCY_ZONE` isn't required and should be hard coded to the value `windows`
2. Note that windows cells should be created in isolated subnets to not conflict with bosh