### PR TITLE
router ip field is for router ips, not load balancers

### DIFF
--- a/_ssl_termin_lb_only_pcf.html.md.erb
+++ b/_ssl_termin_lb_only_pcf.html.md.erb
@@ -33,7 +33,7 @@ address of your load balancer.
 
 1. Click **Networking**.
 
-1. For PCF deployments on OpenStack or vSphere, enter the load balancer IP address that you used to set up a wildcard DNS record in the **Router IPs** field. For more information, see the Elastic Runtime networking configuration topic for [OpenStack](../customizing/openstack-er-config.html#networking) or [vSphere](../customizing/config-er-vmware.html#networking).  
+1. For PCF deployments on OpenStack or vSphere, choose IP addresses for the Gorouters from the subnet configured for Ops Manager and enter the in the **Router IPs** field. Then configure your load balancer to forward requests for the above domains to these IPs. For more information, see the Elastic Runtime networking configuration topic for [OpenStack](../customizing/openstack-er-config.html#networking) or [vSphere](../customizing/config-er-vmware.html#networking).  
 
 1. In the **Certificate and Private Key for HAProxy and Router** fields, enter your PEM-encoded certificate and your PEM-encoded private key. You can either upload your own certificate or generate an RSA certificate in Elastic Runtime. For options and instructions on creating a certificate for your wildcard domains, see [Creating a Wildcard Certificate for PCF Deployments](../opsguide/security_config.html#create_or_obtain_certs).
 


### PR DESCRIPTION
Please update this for all older versions also.