### PR TITLE
Remove question mark

### DIFF
--- a/secure-si-creds.html.md.erb
+++ b/secure-si-creds.html.md.erb
@@ -17,7 +17,7 @@ This topic describes how Pivotal Cloud Foundry (PCF) operators can ensure servic
 	* You must configure PAS to enable this functionality by following the procedure below. Not all services support the use of PAS CredHub.  
 * **Can I use PAS CredHub to store service instance credentials if some of my services do not support the use of PAS CredHub?**
 	*  PAS supports both services that do and do not use PAS CredHub. Services that do not use PAS CredHub continue to pass their credentials to the Cloud Controller database.
-* **Can I rotate service instance credentials in PAS CredHub??**
+* **Can I rotate service instance credentials in PAS CredHub?**
 	* PAS CredHub supports credential rotation. For more information, see the [Rotating PAS CredHub Encryption Keys](../opsguide/credential-rotation.html) topic.
 
 


### PR DESCRIPTION
This removes an item of punctuation (a question mark) that after review I determined was causing an unnecessary double-question-mark situation. Note that formatting, overall layout, and document structure remain unchanged. Punctuation is largely left as-is.

I've not yet updated tests for this change but it works on my machine. Please let me know if you have any questions.