### PR TITLE
Fix formatting in Using Docker Registries

### DIFF
--- a/docker-registry.html.md.erb
+++ b/docker-registry.html.md.erb
@@ -13,8 +13,7 @@ Docker registries store Docker container images. PCF uses these images to create
 
 PCF can only access Docker registries if an operator has enabled Docker support with the `cf enable-feature-flag diego_docker` command, as described in the [Using Docker in Cloud Foundry](../adminguide/docker.html#enable) topic.
 
-With Docker enabled, developers c
-an push an app with a Docker image using the Cloud Foundry Command Line Interface (cf CLI). For more information, see the [Deploy an App with Docker](../devguide/deploy-apps/push-docker.html) topic.
+With Docker enabled, developers can push an app with a Docker image using the Cloud Foundry Command Line Interface (cf CLI). For more information, see the [Deploy an App with Docker](../devguide/deploy-apps/push-docker.html) topic.
 
 ## <a id='ops-man'></a> Use a CA Certificate
 


### PR DESCRIPTION
Due to an unnecessary line-break, the paragraph is split
in the middle of the word.