### PR TITLE
Update adfs-sso-configuration.html.md.erb

### DIFF
--- a/adfs-sso-configuration.html.md.erb
+++ b/adfs-sso-configuration.html.md.erb
@@ -60,7 +60,7 @@ To designate PCF as your SAML service provider (SP) in ADFS, do the following:
 1. Modify your relying party trust as follows:
   1. Double-click the new relying party trust.
   1. Select the **Encryption** tab and click **Remove** to remove the encryption certificate you imported.
-  1. In the **Advanced** tab, select **SHA-1** for the **Secure hash algorithm**.
+  1. In the **Advanced** tab, select **SHA256** for the **Secure hash algorithm**.
 1. (Optional) If you are using a self-signed certificate and want to disable CRL checks, follow these steps:
   1. Open **Windows Powershell** as an Administrator.
   1. Execute the following command: `set-ADFSRelyingPartyTrust -TargetName "RELYING-PARTY-TRUST" -SigningCertificateRevocationCheck None`


### PR DESCRIPTION
According to https://community.pivotal.io/s/article/SHA-Signature-Support-for-SAML-Requests-in-PAS-Tile-in-PCF-20 SHA-1 is no longer supported in version 2.x of PAS.