### PR TITLE
Fixing a calculation error in the scaling recommendation

### DIFF
--- a/_scaling_syslog_adapters.html.md.erb
+++ b/_scaling_syslog_adapters.html.md.erb
@@ -6,6 +6,8 @@ Syslog Adapter is a Loggregator component that manages user-provided syslog drai
 
 Pivotal Application Service (PAS) recommends the following formula for determining the number of Syslog Adapter instances:
 
-<p class="tip"><em>Number of Syslog Adapter instances = Number of drain bindings / 500</em></p>
+<p class="tip"><em>Number of Syslog Adapter instances = Total number of drain bindings * 2 / 500</em></p>
 
-You can use the [`scheduler.drains`](../monitoring/key-cap-scaling.html#scalable-syslog-ksi) and `scheduler.adapters` metrics to configure auto-scaling of Syslog Adapters.
+The syslog scheduler will assign each drain binding to two syslog adapters, therefore doubling the number of the totals. Each syslog adapter will be capable of servicing 500 drain bindings.
+
+You can use the [`scheduler.drains`](../monitoring/key-cap-scaling.html#scalable-syslog-ksi) and `scheduler.adapters` metrics to keep track of the scaling needs of Syslog Adapters.


### PR DESCRIPTION
This should also apply to the 2.3 and tip version of the docs.