### PR TITLE
Update SMB documentation

### DIFF
--- a/enable-vol-services.html.md.erb
+++ b/enable-vol-services.html.md.erb
@@ -98,7 +98,7 @@ To enable SMB volume services in PCF, do the following:
 
 1. Click the **Pivotal Application Service** tile.
 
-1. Select the **Advanced Features** pane.
+1. Select the **Application Containers** pane.
 
 1. Check the box next to **Enable SMB volume services**.
     <%= image_tag('er-config-app-vol-svc-smb.png') %>


### PR DESCRIPTION
Update the SMB documentation to reflect its promotion to general availability so in PCF 2.5 release we are therefore moving the enable checkbox from the `Advanced` tab to the `Application Containers` tab directly underneath the NFS section.

Paul, @davewalter @julian-hj