### PR TITLE
Added note indicating that SAML attribute names are case-sensitive.

### DIFF
--- a/auth-sso.html.md.erb
+++ b/auth-sso.html.md.erb
@@ -61,6 +61,7 @@ To configure PAS to use a SAML IdP, do the following:
 1. For **Email Domain(s)**, enter a comma-separated list of the email domains for external users who will receive invitations to Apps Manager.
 
 1. For **First Name Attribute** and **Last Name Attribute**, enter the attribute names in your SAML database that correspond to the first and last names in each user record, for example `first_name` and `last_name`.
+    <p class="note"><strong>Note:</strong> These and all other attribute names are <strong>case-sensitive</strong>.</p>
 
 1. For **Email Attribute**, enter the attribute name in your SAML assertion that corresponds to the email address in each user record, for example `EmailID`.
 


### PR DESCRIPTION
Case sensitivity required for SAML attribute name matching.