### PR TITLE
Remove link to deprecated anchor in Scaling PAS

### DIFF
--- a/scaling-ert-components.html.md.erb
+++ b/scaling-ert-components.html.md.erb
@@ -68,7 +68,6 @@ If you use one of the following configurations, choose the values in the corresp
 
 * [Deployments Using External Databases](#external-databases)
 * [Deployments Using Internal MySQL](#internal-mysql)
-* [Deployments Using Internal MySQL Databases](#internal-databases)
 * [Deployments Using an External Blobstore](#external-blobstore)
 * [Deployments Using External Load Balancers](#external-lb)
 


### PR DESCRIPTION
Just cleaning house: The `#internal-databases` anchor was [deprecated over a year ago][1]. A second link was added to the new anchor, but the link to the old anchor was never removed. 

[1]: https://github.com/pivotal-cf/docs-ops-guide/commit/af08d42d772fe74c538fbd27e9844e39071d8745#diff-31b01af0980cc3bf4510dd4ae580f511L128 (removes postgres refs)